### PR TITLE
Use the video frame's declared line stride if it is non 0

### DIFF
--- a/src/cyndilib/video_frame.pxd
+++ b/src/cyndilib/video_frame.pxd
@@ -46,7 +46,7 @@ cdef class VideoFrame:
     cdef void _set_timestamp(self, int64_t value) noexcept nogil
     cdef size_t _get_data_size(self) noexcept nogil
     cpdef size_t get_data_size(self)
-    cdef int _recalc_pack_info(self) except -1 nogil
+    cdef int _recalc_pack_info(self, bint use_ptr_stride=*) except -1 nogil
 
 cdef class VideoRecvFrame(VideoFrame):
     cdef readonly size_t max_buffers

--- a/src/cyndilib/video_frame.pyx
+++ b/src/cyndilib/video_frame.pyx
@@ -211,9 +211,12 @@ cdef class VideoFrame:
     cpdef size_t get_data_size(self):
         return self._get_data_size()
 
-    cdef int _recalc_pack_info(self) except -1 nogil:
+    cdef int _recalc_pack_info(self, bint use_ptr_stride=True) except -1 nogil:
         cdef FourCC fcc = self._get_fourcc()
         cdef bint changed = False
+        cdef size_t line_stride = 0
+        if use_ptr_stride:
+            line_stride = self.ptr.line_stride_in_bytes
         if self.pack_info.fourcc != fcc:
             self.pack_info.fourcc = fcc
             changed = True
@@ -224,9 +227,9 @@ cdef class VideoFrame:
         if self.pack_info.xres == 0 or self.pack_info.yres == 0:
             return 0
         if changed:
-            calc_fourcc_pack_info(&(self.pack_info), self.ptr.line_stride_in_bytes)
+            calc_fourcc_pack_info(&(self.pack_info), line_stride)
             # only overwrite our line_stride_in_bytes if it was left unspecified in the NDI video frame.
-            if not self.ptr.line_stride_in_bytes:
+            if not use_ptr_stride:
                 self.ptr.line_stride_in_bytes = self.pack_info.bytes_per_pixel * self.ptr.xres
         return 0
 
@@ -728,6 +731,9 @@ cdef class VideoSendFrame(VideoFrame):
             raise_withgil(PyExc_RuntimeError, 'no write frame available')
         self.send_status.data.write_index = idx
         return &(self.send_status.items[idx])
+
+    cdef int _recalc_pack_info(self, bint use_ptr_stride=False) except -1 nogil:
+        return VideoFrame._recalc_pack_info(self, use_ptr_stride)
 
     cdef bint _send_frame_available(self) noexcept nogil:
         cdef Py_ssize_t idx = frame_status_get_next_read_index(&(self.send_status))

--- a/src/cyndilib/video_frame.pyx
+++ b/src/cyndilib/video_frame.pyx
@@ -224,8 +224,10 @@ cdef class VideoFrame:
         if self.pack_info.xres == 0 or self.pack_info.yres == 0:
             return 0
         if changed:
-            calc_fourcc_pack_info(&(self.pack_info))
-            self.ptr.line_stride_in_bytes = self.pack_info.bytes_per_pixel * self.ptr.xres
+            calc_fourcc_pack_info(&(self.pack_info), self.ptr.line_stride_in_bytes)
+            # only overwrite our line_stride_in_bytes if it was left unspecified in the NDI video frame.
+            if not self.ptr.line_stride_in_bytes:
+                self.ptr.line_stride_in_bytes = self.pack_info.bytes_per_pixel * self.ptr.xres
         return 0
 
 

--- a/src/cyndilib/wrapper/ndi_structs.pxd
+++ b/src/cyndilib/wrapper/ndi_structs.pxd
@@ -318,7 +318,7 @@ cdef FourCCPackInfo* fourcc_pack_info_create() except NULL nogil
 cdef void fourcc_pack_info_init(FourCCPackInfo* fourcc) noexcept nogil
 cdef int fourcc_pack_info_destroy(FourCCPackInfo* p) except -1 nogil
 cdef FourCCPackInfo* get_fourcc_pack_info(FourCC fourcc, size_t xres, size_t yres) except NULL nogil
-cdef int calc_fourcc_pack_info(FourCCPackInfo* p) except -1 nogil
+cdef int calc_fourcc_pack_info(FourCCPackInfo* p, size_t frame_line_stride=*) except -1 nogil
 
 cpdef enum FrameFormat:
     progressive = NDIlib_frame_format_type_progressive


### PR DESCRIPTION
This fixes https://github.com/nocarryr/cyndilib/issues/7

There should probably be additional tests for this edge case but the testing code is a bit beyond me for the time I have to invest.
