### PR TITLE
Update Python version targets

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -27,34 +27,34 @@ on:
 
 
 jobs:
-  test_inplace:
-    name: Test on ${{ matrix.os }}_${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Dependencies
-        run: |
-          python -m pip install -U pip setuptools
-          pip install pytest pytest-xdist psutil
-      - name: Install Project
-        run: pip install -e .
-        env:
-          CYNDILIB_BUILD_PARALLEL: auto
-      - name: Compile tests
-        run: |
-          pip install cython>=0.29.32
-          python build_tests.py
-      - name: Run tests
-        run: py.test
+  # test_inplace:
+  #   name: Test on ${{ matrix.os }}_${{ matrix.python-version }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-latest, macos-latest, windows-latest]
+  #       python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Install Dependencies
+  #       run: |
+  #         python -m pip install -U pip setuptools
+  #         pip install pytest pytest-xdist psutil
+  #     - name: Install Project
+  #       run: pip install -e .
+  #       env:
+  #         CYNDILIB_BUILD_PARALLEL: auto
+  #     - name: Compile tests
+  #       run: |
+  #         pip install cython>=0.29.32
+  #         python build_tests.py
+  #     - name: Run tests
+  #       run: py.test
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}_${{ matrix.python-version }}-${{ matrix.arch }}
@@ -75,21 +75,21 @@ jobs:
         - os: windows-latest
           arch: AMD64
           python-version: "cp3{8,9,10,11,12}"
-        - os: ubuntu-latest
-          arch: aarch64
-          python-version: "cp38"
-        - os: ubuntu-latest
-          arch: aarch64
-          python-version: "cp39"
-        - os: ubuntu-latest
-          arch: aarch64
-          python-version: "cp310"
-        - os: ubuntu-latest
-          arch: aarch64
-          python-version: "cp311"
-        - os: ubuntu-latest
-          arch: aarch64
-          python-version: "cp312"
+        # - os: ubuntu-latest
+        #   arch: aarch64
+        #   python-version: "cp38"
+        # - os: ubuntu-latest
+        #   arch: aarch64
+        #   python-version: "cp39"
+        # - os: ubuntu-latest
+        #   arch: aarch64
+        #   python-version: "cp310"
+        # - os: ubuntu-latest
+        #   arch: aarch64
+        #   python-version: "cp311"
+        # - os: ubuntu-latest
+        #   arch: aarch64
+        #   python-version: "cp312"
 
     steps:
       - uses: actions/checkout@v3
@@ -142,7 +142,7 @@ jobs:
 
   deploy:
       name: 'Deploy to PyPI'
-      needs: [test_inplace, build_wheels]
+      needs: [build_wheels]
       runs-on: ubuntu-latest
       if: ${{ inputs.allow_deploy }}
       permissions:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -27,34 +27,34 @@ on:
 
 
 jobs:
-  # test_inplace:
-  #   name: Test on ${{ matrix.os }}_${{ matrix.python-version }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-latest, macos-latest, windows-latest]
-  #       python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install Dependencies
-  #       run: |
-  #         python -m pip install -U pip setuptools
-  #         pip install pytest pytest-xdist psutil
-  #     - name: Install Project
-  #       run: pip install -e .
-  #       env:
-  #         CYNDILIB_BUILD_PARALLEL: auto
-  #     - name: Compile tests
-  #       run: |
-  #         pip install cython>=0.29.32
-  #         python build_tests.py
-  #     - name: Run tests
-  #       run: py.test
+  test_inplace:
+    name: Test on ${{ matrix.os }}_${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install -U pip setuptools
+          pip install pytest pytest-xdist psutil
+      - name: Install Project
+        run: pip install -e .
+        env:
+          CYNDILIB_BUILD_PARALLEL: auto
+      - name: Compile tests
+        run: |
+          pip install cython>=0.29.32
+          python build_tests.py
+      - name: Run tests
+        run: py.test
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}_${{ matrix.python-version }}-${{ matrix.arch }}
@@ -75,21 +75,21 @@ jobs:
         - os: windows-latest
           arch: AMD64
           python-version: "cp3{9,10,11,12,13}"
-        # - os: ubuntu-latest
-        #   arch: aarch64
-        #   python-version: "cp38"
-        # - os: ubuntu-latest
-        #   arch: aarch64
-        #   python-version: "cp39"
-        # - os: ubuntu-latest
-        #   arch: aarch64
-        #   python-version: "cp310"
-        # - os: ubuntu-latest
-        #   arch: aarch64
-        #   python-version: "cp311"
-        # - os: ubuntu-latest
-        #   arch: aarch64
-        #   python-version: "cp312"
+        - os: ubuntu-latest
+          arch: aarch64
+          python-version: "cp39"
+        - os: ubuntu-latest
+          arch: aarch64
+          python-version: "cp310"
+        - os: ubuntu-latest
+          arch: aarch64
+          python-version: "cp311"
+        - os: ubuntu-latest
+          arch: aarch64
+          python-version: "cp312"
+        - os: ubuntu-latest
+          arch: aarch64
+          python-version: "cp313"
 
     steps:
       - uses: actions/checkout@v3
@@ -141,7 +141,7 @@ jobs:
 
   deploy:
       name: 'Deploy to PyPI'
-      needs: [build_wheels]
+      needs: [test_inplace, build_wheels]
       runs-on: ubuntu-latest
       if: ${{ inputs.allow_deploy }}
       permissions:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -65,16 +65,16 @@ jobs:
         include:
         - os: macos-13
           arch: x86_64
-          python-version: "cp3{10,11,12,13}"
+          python-version: "cp3{9,10,11,12,13}"
         - os: macos-14
           arch: arm64
-          python-version: "cp3{10,11,12,13}"
+          python-version: "cp3{9,10,11,12,13}"
         - os: ubuntu-latest
           arch: x86_64
-          python-version: "cp3{10,11,12,13}"
+          python-version: "cp3{9,10,11,12,13}"
         - os: windows-latest
           arch: AMD64
-          python-version: "cp3{10,11,12,13}"
+          python-version: "cp3{9,10,11,12,13}"
         # - os: ubuntu-latest
         #   arch: aarch64
         #   python-version: "cp38"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Build wheels
         id: build_wheel
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: ${{ matrix.python-version }}-*
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -127,7 +127,6 @@ jobs:
           CIBW_BUILD: ${{ matrix.python-version }}-*
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_TEST_SKIP: ${{ steps.cibuildwheel_env.outputs.test_skip }}
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} --all --depending && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
         if: ${{ inputs.os_type }} != "" && (${{ inputs.os_type }} == matrix.os || ${{ inputs.os_type }} == "all")
         #    ...
         # with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -100,7 +100,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
         if: runner.os == 'macOS' && runner.arch == 'ARM64'
 
       - name: Set cibuildwheel env

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,7 +2,7 @@ name: Build Wheels
 
 on:
   push:
-    branches: [ main, cibw-upgrade ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,7 +2,7 @@ name: Build Wheels
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, cibw-upgrade ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -65,16 +65,16 @@ jobs:
         include:
         - os: macos-13
           arch: x86_64
-          python-version: "cp3{8,9,10,11,12}"
+          python-version: "cp3{10,11,12,13}"
         - os: macos-14
           arch: arm64
-          python-version: "cp3{8,9,10,11,12}"
+          python-version: "cp3{10,11,12,13}"
         - os: ubuntu-latest
           arch: x86_64
-          python-version: "cp3{8,9,10,11,12}"
+          python-version: "cp3{10,11,12,13}"
         - os: windows-latest
           arch: AMD64
-          python-version: "cp3{8,9,10,11,12}"
+          python-version: "cp3{10,11,12,13}"
         # - os: ubuntu-latest
         #   arch: aarch64
         #   python-version: "cp38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,3 @@ before-all = "yum install -y avahi-libs"
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = "apk add avahi-libs"
-
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx*"
-dependency-versions = "./constraints-macosx.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,7 @@ before-all = "yum install -y avahi-libs"
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = "apk add avahi-libs"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx*"
+dependency-versions = "./constraints-macosx.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "numpy", "cython>=0.29.32"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.cibuildwheel]
-build = "cp3{9,10,11,13}-*"
+build = "cp3{9,10,11,12,13}-*"
 skip = "*-musllinux*"
 test-requires = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "numpy", "cython>=0.29.32"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.cibuildwheel]
-build = "cp3{7,8,9,10,11}-*"
+build = "cp3{9,10,11,13}-*"
 skip = "*-musllinux*"
 test-requires = [
     "pytest",

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,11 @@ classifiers =
     Programming Language :: Cython
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Multimedia
     Topic :: Multimedia :: Sound/Audio


### PR DESCRIPTION
Drop Py3.8 and add Py3.13

This required a version update for cibuildwheel (from 2.19.2 to 2.22.0).  Thankfully `delocate` can still be constrained to [v0.10.7](https://github.com/matthew-brett/delocate/tree/0.10.7) to avoid issues with `libndi.dylib` not satisfying the deployment target (see  cb132bf3f and 14532803).   Since it's a third-party binary and only being included in the wheel (not as a compiled extension module) it's mostly a false positive 