### PR TITLE
Consistently use `size_t`, cast to `Py_ssize_t` where needed

### DIFF
--- a/src/cyndilib/audio_frame.pxd
+++ b/src/cyndilib/audio_frame.pxd
@@ -50,9 +50,9 @@ cdef class AudioRecvFrame(AudioFrame):
     cdef readonly cnp.ndarray current_frame_data
     cdef readonly uint32_t current_timecode
     cdef readonly uint32_t current_timestamp
-    cdef Py_ssize_t[2] bfr_shape
-    cdef Py_ssize_t[2] bfr_strides
-    cdef Py_ssize_t[2] empty_bfr_shape
+    cdef size_t[2] bfr_shape
+    cdef size_t[2] bfr_strides
+    cdef size_t[2] empty_bfr_shape
     cdef readonly size_t view_count
 
     cpdef size_t get_buffer_depth(self)
@@ -85,8 +85,8 @@ cdef class AudioRecvFrame(AudioFrame):
 
 cdef class AudioFrameSync(AudioFrame):
     cdef NDIlib_framesync_instance_t fs_ptr
-    cdef readonly Py_ssize_t[2] shape
-    cdef readonly Py_ssize_t[2] strides
+    cdef readonly size_t[2] shape
+    cdef readonly size_t[2] strides
     cdef size_t view_count
 
     cdef int _process_incoming(self, NDIlib_framesync_instance_t fs_ptr) except -1 nogil

--- a/src/cyndilib/send_frame_status.pxd
+++ b/src/cyndilib/send_frame_status.pxd
@@ -11,26 +11,26 @@ cdef extern from *:
     """
     cdef const size_t MAX_FRAME_BUFFERS
     cdef const Py_intptr_t NULL_ID
-    cdef const Py_ssize_t NULL_INDEX
+    cdef const size_t NULL_INDEX
 
 
 cdef struct SendFrame_item_s:
-    Py_ssize_t idx
-    Py_ssize_t view_count
-    Py_ssize_t alloc_size
+    size_t idx
+    size_t view_count
+    size_t alloc_size
     bint write_available
     bint read_available
-    Py_ssize_t[3] shape
-    Py_ssize_t[3] strides
+    size_t[3] shape
+    size_t[3] strides
 
 
 cdef struct SendFrame_status_s:
-    Py_ssize_t num_buffers
-    Py_ssize_t write_index
-    Py_ssize_t read_index
-    Py_ssize_t ndim
-    Py_ssize_t[3] shape
-    Py_ssize_t[3] strides
+    size_t num_buffers
+    size_t write_index
+    size_t read_index
+    size_t ndim
+    size_t[3] shape
+    size_t[3] strides
     bint attached_to_sender
 
 cdef struct VideoSendFrame_item_s:
@@ -69,11 +69,11 @@ cdef int frame_status_alloc_p_data(SendFrame_status_s_ft* ptr) except -1 nogil
 cdef void frame_status_set_send_ready(SendFrame_status_s_ft* ptr) noexcept nogil
 cdef void frame_status_set_send_complete(
     SendFrame_status_s_ft* ptr,
-    Py_ssize_t idx,
+    size_t idx,
 ) noexcept nogil
-cdef Py_ssize_t frame_status_get_next_write_index(
+cdef size_t frame_status_get_next_write_index(
     SendFrame_status_s_ft* ptr,
 ) noexcept nogil
-cdef Py_ssize_t frame_status_get_next_read_index(
+cdef size_t frame_status_get_next_read_index(
     SendFrame_status_s_ft* ptr,
 ) noexcept nogil

--- a/src/cyndilib/send_frame_status.pyx
+++ b/src/cyndilib/send_frame_status.pyx
@@ -6,7 +6,7 @@ cdef int frame_status_init(SendFrame_status_s_ft* ptr) except -1 nogil:
     ptr.data.read_index = NULL_INDEX
     ptr.data.ndim = 0
     ptr.data.attached_to_sender = False
-    cdef Py_ssize_t i
+    cdef size_t i
     for i in range(3):
         ptr.data.shape[i] = 0
         ptr.data.strides[i] = 0
@@ -95,7 +95,7 @@ cdef int frame_status_alloc_p_data(SendFrame_status_s_ft* ptr) except -1 nogil:
     if ptr.data.ndim < 1 or ptr.data.ndim > 3:
         raise_withgil(PyExc_ValueError, 'ndim must be between 1 and 3')
 
-    cdef Py_ssize_t total_size = ptr.data.strides[ptr.data.ndim-1]
+    cdef size_t total_size = ptr.data.strides[ptr.data.ndim-1]
     cdef size_t i
 
     for i in range(ptr.data.ndim):
@@ -110,9 +110,9 @@ cdef int frame_status_alloc_p_data(SendFrame_status_s_ft* ptr) except -1 nogil:
 
 cdef int frame_status_item_alloc_p_data(
     SendFrame_item_s_ft* ptr,
-    Py_ssize_t total_size,
-    Py_ssize_t[3] shape,
-    Py_ssize_t[3] strides,
+    size_t total_size,
+    size_t[3] shape,
+    size_t[3] strides,
 ) except -1 nogil:
 
     cdef size_t i
@@ -137,16 +137,16 @@ cdef void frame_status_item_free_p_data(SendFrame_item_s_ft* ptr) noexcept nogil
     ptr.data.alloc_size = 0
 
 cdef void frame_status_set_send_ready(SendFrame_status_s_ft* ptr) noexcept nogil:
-    cdef Py_ssize_t idx = ptr.data.write_index
+    cdef size_t idx = ptr.data.write_index
     ptr.items[idx].data.write_available = False
     ptr.items[idx].data.read_available = True
     ptr.data.read_index = idx
     ptr.data.write_index = frame_status_get_next_write_index(ptr)
 
-cdef Py_ssize_t frame_status_get_next_write_index(
+cdef size_t frame_status_get_next_write_index(
     SendFrame_status_s_ft* ptr,
 ) noexcept nogil:
-    cdef Py_ssize_t next_idx = ptr.data.write_index, i = 0
+    cdef size_t next_idx = ptr.data.write_index, i = 0
     while True:
         if ptr.items[next_idx].data.write_available:
             return next_idx
@@ -159,7 +159,7 @@ cdef Py_ssize_t frame_status_get_next_write_index(
 
 cdef void frame_status_set_send_complete(
     SendFrame_status_s_ft* ptr,
-    Py_ssize_t idx,
+    size_t idx,
 ) noexcept nogil:
 
     ptr.items[idx].data.write_available = True
@@ -168,11 +168,11 @@ cdef void frame_status_set_send_complete(
         ptr.data.read_index = frame_status_get_next_read_index(ptr)
 
 
-cdef Py_ssize_t frame_status_get_next_read_index(
+cdef size_t frame_status_get_next_read_index(
     SendFrame_status_s_ft* ptr,
 ) noexcept nogil:
 
-    cdef Py_ssize_t idx = ptr.data.read_index, i = 0
+    cdef size_t idx = ptr.data.read_index, i = 0
     if idx == NULL_INDEX:
         with cython.cdivision(True):
             idx = (ptr.data.write_index - 1) % MAX_FRAME_BUFFERS

--- a/src/cyndilib/sender.pyx
+++ b/src/cyndilib/sender.pyx
@@ -236,7 +236,7 @@ cdef class Sender:
 
         vid_item = self.video_frame._prepare_buffer_write()
         aud_item = self.audio_frame._prepare_buffer_write()
-        cdef Py_ssize_t* outer_shape = self.audio_frame.send_status.data.shape
+        cdef size_t* outer_shape = self.audio_frame.send_status.data.shape
         cdef cnp.uint8_t[:] vid_memview = self.video_frame
         cdef cnp.float32_t[:,:] aud_memview = self.audio_frame
 

--- a/src/cyndilib/video_frame.pxd
+++ b/src/cyndilib/video_frame.pxd
@@ -63,8 +63,8 @@ cdef class VideoRecvFrame(VideoFrame):
     cdef readonly Condition write_ready
     cdef cnp.ndarray all_frame_data
     cdef readonly cnp.ndarray current_frame_data
-    cdef Py_ssize_t[1] bfr_shape
-    cdef Py_ssize_t[1] bfr_strides
+    cdef size_t[1] bfr_shape
+    cdef size_t[1] bfr_strides
     cdef size_t view_count
 
     cdef int _check_read_array_size(self) except -1
@@ -78,8 +78,8 @@ cdef class VideoRecvFrame(VideoFrame):
 
 cdef class VideoFrameSync(VideoFrame):
     cdef NDIlib_framesync_instance_t fs_ptr
-    cdef readonly Py_ssize_t[1] shape
-    cdef readonly Py_ssize_t[1] strides
+    cdef readonly size_t[1] shape
+    cdef readonly size_t[1] strides
     cdef size_t view_count
 
     cdef int _process_incoming(self, NDIlib_framesync_instance_t fs_ptr) except -1 nogil

--- a/src/cyndilib/video_frame.pyx
+++ b/src/cyndilib/video_frame.pyx
@@ -326,8 +326,8 @@ cdef class VideoRecvFrame(VideoFrame):
         buffer.ndim = frame_data.ndim
         buffer.obj = self
         buffer.readonly = 1
-        buffer.shape = self.bfr_shape
-        buffer.strides = self.bfr_strides
+        buffer.shape = <Py_ssize_t*>self.bfr_shape
+        buffer.strides = <Py_ssize_t*>self.bfr_strides
         buffer.suboffsets = NULL
 
     def __releasebuffer__(self, Py_buffer *buffer):
@@ -673,8 +673,8 @@ cdef class VideoSendFrame(VideoFrame):
         buffer.ndim = self.send_status.data.ndim
         buffer.obj = self
         buffer.readonly = 0
-        buffer.shape = item.data.shape
-        buffer.strides = item.data.strides
+        buffer.shape = <Py_ssize_t*>item.data.shape
+        buffer.strides = <Py_ssize_t*>item.data.strides
         buffer.suboffsets = NULL
 
     def __releasebuffer__(self, Py_buffer *buffer):
@@ -688,7 +688,7 @@ cdef class VideoSendFrame(VideoFrame):
         return self._write_available()
 
     cdef bint _write_available(self) noexcept nogil:
-        cdef Py_ssize_t idx = frame_status_get_next_write_index(&(self.send_status))
+        cdef size_t idx = frame_status_get_next_write_index(&(self.send_status))
         return idx != NULL_INDEX
 
     cdef VideoSendFrame_item_s* _prepare_buffer_write(self) except NULL nogil:
@@ -744,7 +744,7 @@ cdef class VideoSendFrame(VideoFrame):
         self._set_buffer_write_complete(item)
 
     cdef VideoSendFrame_item_s* _get_next_write_frame(self) except NULL nogil:
-        cdef Py_ssize_t idx = frame_status_get_next_write_index(&(self.send_status))
+        cdef size_t idx = frame_status_get_next_write_index(&(self.send_status))
         if idx == NULL_INDEX:
             raise_withgil(PyExc_RuntimeError, 'no write frame available')
         self.send_status.data.write_index = idx
@@ -754,11 +754,11 @@ cdef class VideoSendFrame(VideoFrame):
         return VideoFrame._recalc_pack_info(self, use_ptr_stride)
 
     cdef bint _send_frame_available(self) noexcept nogil:
-        cdef Py_ssize_t idx = frame_status_get_next_read_index(&(self.send_status))
+        cdef size_t idx = frame_status_get_next_read_index(&(self.send_status))
         return idx != NULL_INDEX
 
     cdef VideoSendFrame_item_s* _get_send_frame(self) except NULL nogil:
-        cdef Py_ssize_t idx = frame_status_get_next_read_index(&(self.send_status))
+        cdef size_t idx = frame_status_get_next_read_index(&(self.send_status))
         if idx == NULL_INDEX:
             raise_withgil(PyExc_IndexError, 'no read index available')
         return &(self.send_status.items[idx])
@@ -770,7 +770,7 @@ cdef class VideoSendFrame(VideoFrame):
         :meth:`_send_frame_available` must be checked before calling this
         or bad things could happen
         """
-        cdef Py_ssize_t idx = frame_status_get_next_read_index(&(self.send_status))
+        cdef size_t idx = frame_status_get_next_read_index(&(self.send_status))
         return &(self.send_status.items[idx])
 
     cdef void _on_sender_write(self, VideoSendFrame_item_s* s_ptr) noexcept nogil:


### PR DESCRIPTION
Reduces comparisons between differing "signednesses"