### PR TITLE
Revert back to blacksmith runner for codspeed benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,11 +26,7 @@ on:
 
 jobs:
   benchmark:
-    runs-on: codspeed-macro
-    strategy:
-      fail-fast: false
-      matrix:
-        instrumentation-mode: [simulation, walltime]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 
@@ -55,5 +51,5 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: ${{ matrix.instrumentation-mode }}
+          mode: simulation
           run: uv run py.test tests/ --codspeed -n=0


### PR DESCRIPTION
This reverts #71. 

Walltime instrumentation has proven to be too inconsistent for this project.  Also, the macro runners do not provide profiling information for flame graphs in simulation mode.