### PR TITLE
Use blacksmith runners for macos arm64

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}_${{ matrix.python-version }}-${{ matrix.arch }}
+    name: Build wheels on ${{ matrix.os }}_${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     env:
       CIBW_ARCHS: |-
@@ -65,13 +65,7 @@ jobs:
           - "blacksmith-2vcpu-windows-2025"
           - "blacksmith-4vcpu-ubuntu-2404-arm"
           - "blacksmith-6vcpu-macos-latest"
-        include:
-        - os: macos-15-intel
-          arch: x86_64
-          python-version: "cp3{10,11}"
-        - os: macos-15-intel
-          arch: x86_64
-          python-version: "cp3{12,13,14}"
+          - "macos-15-intel"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -50,7 +50,7 @@ jobs:
       CIBW_ARCHS: |-
         ${{ case(
           matrix.os == 'macos-15-intel', 'x86_64',
-          matrix.os == 'macos-latest' && matrix.arch == 'arm64', 'arm64',
+          startsWith(matrix.os, 'blacksmith') && contains(matrix.os, 'macos'), 'arm64',
           startsWith(matrix.os, 'blacksmith') && contains(matrix.os, 'ubuntu') && !contains(matrix.os, 'arm'), 'x86_64',
           startsWith(matrix.os, 'blacksmith') && contains(matrix.os, 'ubuntu') && contains(matrix.os, 'arm'), 'aarch64',
           startsWith(matrix.os, 'blacksmith') && contains(matrix.os, 'windows'), 'AMD64',
@@ -60,7 +60,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["cp310", "cp311", "cp312", "cp313", "cp314"]
-        os: [ "blacksmith-2vcpu-ubuntu-2404", "blacksmith-2vcpu-windows-2025", "blacksmith-4vcpu-ubuntu-2404-arm"]
+        os:
+          - "blacksmith-2vcpu-ubuntu-2404"
+          - "blacksmith-2vcpu-windows-2025"
+          - "blacksmith-4vcpu-ubuntu-2404-arm"
+          - "blacksmith-6vcpu-macos-latest"
         include:
         - os: macos-15-intel
           arch: x86_64
@@ -68,9 +72,6 @@ jobs:
         - os: macos-15-intel
           arch: x86_64
           python-version: "cp3{12,13,14}"
-        - os: macos-latest
-          arch: arm64
-          python-version: "cp3{10,11,12,13,14}"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [blacksmith-2vcpu-ubuntu-2404, macos-latest, blacksmith-2vcpu-windows-2025]
+        os: [blacksmith-2vcpu-ubuntu-2404, blacksmith-6vcpu-macos-latest, blacksmith-2vcpu-windows-2025]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       UV_PYTHON: ${{ matrix.python-version }}


### PR DESCRIPTION
🔥Wow, @useblacksmith !!!  Thanks for adding macos runners! 🔥

This may blow my free tier budget, but I may consider paying for this!

Build time just went down by over 50% not having to wait for the github queue!