### PR TITLE
Skip `delvewheel` repair command in windows builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ before-all = [
     "uv export --frozen --no-emit-project --no-build --only-group test -o pylock.toml",
 ]
 
+[tool.cibuildwheel.windows]
+repair-wheel-command = ""
+
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = [


### PR DESCRIPTION
cibuildwheel>=v4.0 added delvewheel by default.  Per their docs:

> If a wheel has a platform tag but contains no extension module (for example, a package that sets a platform tag but ships a pre-built DLL itself), `delvewheel` may error. In that case, set `repair-wheel-command = ""` to skip the repair step.

See:
https://cibuildwheel.pypa.io/en/v4.1.0/options/#repair-wheel-command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->