### PR TITLE
Move back to github-hosted macos runners in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [blacksmith-2vcpu-ubuntu-2404, blacksmith-6vcpu-macos-latest, blacksmith-2vcpu-windows-2025]
+        os: [blacksmith-2vcpu-ubuntu-2404, macos-latest, blacksmith-2vcpu-windows-2025]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       UV_PYTHON: ${{ matrix.python-version }}


### PR DESCRIPTION
As incredibly fast as it's been using blacksmith macos runners, the cost is beginning to creep a bit much.

Moving one workflow back to github's runners so we at least don't run into the concurrency limit (5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS test environment used by automated checks.
  * Python versions and existing installation, compilation, and test steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->