### PR TITLE
Reduce renovate noise with grouping, release age and rebase policies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,8 +19,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "groupName": "github-actions-all",
-      "groupMilestone": true
+      "groupName": "github-actions-all"
     }
   ],
   "lockFileMaintenance": {

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
     "config:best-practices"
   ],
   "labels": ["dependencies"],
+  "minimumReleaseAge": "7 days",
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchPackageNames": ["cython"],
@@ -14,6 +16,11 @@
       "matchFileNames": [".github/workflows/codspeed.yml"],
       "matchPackageNames": ["actions/python-versions"],
       "allowedVersions": "3.13"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions-all",
+      "groupMilestone": true
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Update scheduling is now delayed by seven days to allow additional validation.
  * Conflicting update branches are automatically rebased.
  * GitHub Actions updates are grouped together and share a milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->